### PR TITLE
Dock Step 0: Bidirectional IPC proof of concept

### DIFF
--- a/src/webview_app.rs
+++ b/src/webview_app.rs
@@ -5,8 +5,21 @@
 //!
 //! The WASM binary and JS glue are embedded at compile time.
 //! Run `make wasm` before `make webview` to generate the `pkg/` assets.
+//!
+//! # Threading model
+//!
+//! `WebView` is not `Send`. All WebView interaction must happen on the main
+//! thread inside the event loop handler.
+//!
+//! Host → WebView: background threads send `UserEvent::ScriptToRun(script)`
+//! via `EventLoopProxy`. The event loop calls `webview.evaluate_script()`.
+//!
+//! WebView → Host: JS calls `window.ipc.postMessage("...")`, wry fires the
+//! `with_ipc_handler` closure on the main thread.
 
 use std::borrow::Cow;
+use std::thread;
+use std::time::Duration;
 use wry::{
     application::{
         event::{Event, WindowEvent},
@@ -23,8 +36,31 @@ const INDEX_HTML:  &[u8] = include_bytes!("../index.html");
 const LILBUD_JS:   &[u8] = include_bytes!("../pkg/lilbud.js");
 const LILBUD_WASM: &[u8] = include_bytes!("../pkg/lilbud_bg.wasm");
 
+/// Events sent from background threads to the main event loop.
+/// The event loop calls `webview.evaluate_script()` for each one.
+#[derive(Debug)]
+pub enum UserEvent {
+    /// Run an arbitrary JS snippet in the WebView.
+    ScriptToRun(String),
+}
+
 pub fn run() {
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::<UserEvent>::with_user_event();
+    let proxy = event_loop.create_proxy();
+
+    // Proof-of-concept background thread: sends a JS ping to the WebView
+    // every 2 seconds. Replace with real serial / board logic in Step 5.
+    thread::spawn(move || {
+        let mut n = 0u32;
+        loop {
+            thread::sleep(Duration::from_secs(2));
+            let script = format!("console.log('host ping {n}')");
+            if proxy.send_event(UserEvent::ScriptToRun(script)).is_err() {
+                break; // event loop exited
+            }
+            n += 1;
+        }
+    });
 
     let window = WindowBuilder::new()
         .with_title("lilbud")
@@ -33,7 +69,7 @@ pub fn run() {
         .build(&event_loop)
         .unwrap();
 
-    let _webview = WebViewBuilder::new(window)
+    let webview = WebViewBuilder::new(window)
         .unwrap()
         .with_custom_protocol("app".into(), |request| {
             let path = request.uri().path();
@@ -51,6 +87,10 @@ pub fn run() {
                 .body(Cow::Borrowed(body))
                 .map_err(Into::into)
         })
+        .with_ipc_handler(|_window, msg| {
+            // WebView → Host: JS called window.ipc.postMessage("...")
+            eprintln!("[ipc] received from JS: {msg}");
+        })
         .with_url("app://localhost/")
         .unwrap()
         .build()
@@ -58,8 +98,17 @@ pub fn run() {
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
-        if let Event::WindowEvent { event: WindowEvent::CloseRequested, .. } = event {
-            *control_flow = ControlFlow::Exit;
+        match event {
+            Event::WindowEvent { event: WindowEvent::CloseRequested, .. } => {
+                *control_flow = ControlFlow::Exit;
+            }
+            Event::UserEvent(UserEvent::ScriptToRun(script)) => {
+                // Host → WebView: run JS on the main thread
+                if let Err(e) = webview.evaluate_script(&script) {
+                    eprintln!("[webview] evaluate_script error: {e}");
+                }
+            }
+            _ => {}
         }
     });
 }


### PR DESCRIPTION
Closes #3

## What this does

Establishes the host ↔ WebView communication pattern that all dock serial logic will build on.

`WebView` is not `Send` in wry 0.24 (tao backend), so cross-thread communication requires an indirection layer:

- **Host → WebView**: background threads send `UserEvent::ScriptToRun(String)` via `EventLoopProxy`; the event loop calls `webview.evaluate_script()` on the main thread
- **WebView → Host**: JS calls `window.ipc.postMessage("...")`, wry fires `with_ipc_handler` closure on the main thread

## Changes

- `UserEvent` enum with `ScriptToRun(String)` variant
- `EventLoop::<UserEvent>::with_user_event()` (tao API — not winit's `::new()`)
- `with_ipc_handler` wired up — currently logs JS messages to stderr
- Placeholder background thread pings the WebView every 2s via proxy — will be replaced by the serial board frame reader in Step 5 (#8)
- `webview` held for the event loop closure lifetime (was previously `_webview`, immediately dropped)

## Testing

```sh
make wasm   # generate pkg/ assets first
make webview
```

- Open WebView devtools → Console: `host ping 0`, `host ping 1`, ... every 2s (host → WebView confirmed)
- Run `window.ipc.postMessage("hello from JS")` in devtools console → `[ipc] received from JS: hello from JS` in terminal (WebView → host confirmed)